### PR TITLE
wip: NEAR code review

### DIFF
--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -12,32 +12,32 @@ import { Promise, ReturnedPromise, Vote, promises } from './model';
  * Returns an array of last N promises.\
  * NOTE: This is a NOT a view method at the moment. Which means it costs money so shouldn't be executed too frequently.
  */
- export function getPromises(target: string): ReturnedPromise[] {
+export function getPromises(target: string): ReturnedPromise[] {
   assert(Context.predecessor == Context.sender)
 
   const result = new Array<ReturnedPromise>()
   const forMe = (target == 'me')
   // logging.log('getPromises: sender = ' + Context.sender + ', target = ' + target + ', forMe = ' + forMe.toString())
 
-  for(let i = 0; i < promises.length; ++i) {
+  for (let i = 0; i < promises.length; ++i) {
     // logging.log('getPromises: promise = ' + promises[i].who + ', promises[i].who === Context.sender = ' + (promises[i].who == Context.sender).toString())
 
     let promise = promises[i]
-    if(forMe == true) {
-      if(promise.who == Context.sender)
+    if (forMe == true) {
+      if (promise.who == Context.sender)
         result.push(new ReturnedPromise(i, promise))
     } else {
       var isPublicNotMinePromise = promise.canView.size == 0 && promise.who != Context.sender
       var canViewPromise = (isPublicNotMinePromise ? true : promise.canView.has(Context.sender))
 
-      if(canViewPromise)
+      if (canViewPromise)
         result.push(new ReturnedPromise(i, promise))
     }
   }
   return result;
- }
+}
 
-export function vote(promiseId: i32, value: boolean) : ReturnedPromise {
+export function vote(promiseId: i32, value: boolean): ReturnedPromise {
   assert(Context.predecessor == Context.sender)
   assert(promiseId >= 0 && promiseId < promises.length)
 
@@ -49,37 +49,36 @@ export function vote(promiseId: i32, value: boolean) : ReturnedPromise {
   assert(isAllowedToVote)
 
   let newVote = value == true ? Vote.Yes : Vote.No
-  if(promise.votes.has(Context.predecessor)) {
+  if (promise.votes.has(Context.predecessor)) {
     logging.log('vote: re-vote...')
 
     let voteValue = promise.votes.get(Context.predecessor);
     logging.log('voteValue = ' + voteValue.toString())
 
-    if(newVote != voteValue) {
+    if (newVote != voteValue) {
       logging.log('value != voteValue')
 
       promise.votes.set(Context.predecessor, newVote);
-      if(voteValue == Vote.Yes) {
+      if (voteValue == Vote.Yes) {
         logging.log('re-vote to no')
 
         promise.vote_yes -= 1
-        promise.vote_no += 1 
+        promise.vote_no += 1
       } else {
         logging.log('re-vote to yes')
 
         promise.vote_yes += 1
         promise.vote_no -= 1
       }
-    } 
-    else 
-    {
+    }
+    else {
       logging.log('value = voteValue = ' + value.toString())
     }
   } else {
     logging.log('vote: new vote...')
 
     promise.votes.set(Context.predecessor, newVote);
-    if(value == true) {
+    if (value == true) {
       logging.log('vote to yes')
       promise.vote_yes += 1
     } else {
@@ -89,17 +88,17 @@ export function vote(promiseId: i32, value: boolean) : ReturnedPromise {
   }
 
   logging.log('vote: replacing promiseId ' + promiseId.toString() + ' with promise = '
-   + promise.vote_yes.toString() + "/" + promise.vote_no.toString())
+    + promise.vote_yes.toString() + "/" + promise.vote_no.toString())
 
   promises.replace(promiseId, promise);
   return new ReturnedPromise(promiseId, promises[promiseId])
 }
 
-export function makeExtendedPromise(what: string, viewers: string[], voters: string[]) : ReturnedPromise {
+export function makeExtendedPromise(what: string, viewers: string[], voters: string[]): ReturnedPromise {
   assert(Context.predecessor == Context.sender)
 
   var promise = new Promise(what)
-  for(let i = 0; i < viewers.length; ++i) {
+  for (let i = 0; i < viewers.length; ++i) {
     let viewer = viewers[i];
     assert(env.isValidAccountID(viewer), "viewer account is invalid")
 
@@ -107,7 +106,7 @@ export function makeExtendedPromise(what: string, viewers: string[], voters: str
     promise.canView.add(viewer)
   }
 
-  for(let i = 0; i < voters.length; ++i) {
+  for (let i = 0; i < voters.length; ++i) {
     let voter = voters[i];
     assert(env.isValidAccountID(voter), "voter account is invalid")
 
@@ -123,17 +122,17 @@ export function makeExtendedPromise(what: string, viewers: string[], voters: str
   return new ReturnedPromise(promises.length - 1, promises[promises.length - 1])
 }
 
-export function makePromise(what: string) : ReturnedPromise {
+export function makePromise(what: string): ReturnedPromise {
   assert(Context.predecessor == Context.sender)
 
   promises.push(new Promise(what));
   return new ReturnedPromise(promises.length - 1, promises[promises.length - 1])
 }
 
-// debug only 
+// debug only
 export function clearAll(): void {
   assert(Context.predecessor == Context.sender)
 
-  while(promises.length !== 0)
+  while (promises.length !== 0)
     promises.pop();
 }

--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -27,8 +27,8 @@ export function getPromises(target: string): ReturnedPromise[] {
       if (promise.who == Context.sender)
         result.push(new ReturnedPromise(i, promise))
     } else {
-      var isPublicNotMinePromise = promise.canView.size == 0 && promise.who != Context.sender
-      var canViewPromise = (isPublicNotMinePromise ? true : promise.canView.has(Context.sender))
+      const isPublicNotMinePromise = promise.canView.size == 0 && promise.who != Context.sender
+      const canViewPromise = (isPublicNotMinePromise ? true : promise.canView.has(Context.sender))
 
       if (canViewPromise)
         result.push(new ReturnedPromise(i, promise))
@@ -97,7 +97,7 @@ export function vote(promiseId: i32, value: boolean): ReturnedPromise {
 export function makePromise(what: string, viewers: string[] = [], voters: string[] = []): ReturnedPromise {
   assertDirectCall()
 
-  var promise = new Promise(what)
+  const promise = new Promise(what)
   for (let i = 0; i < viewers.length; ++i) {
     let viewer = viewers[i];
     assert(env.isValidAccountID(viewer), "viewer account is invalid")

--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -5,7 +5,7 @@
  *
  */
 
-import { Context, env, logging, PersistentMap, PersistentVector, storage } from 'near-sdk-as'
+import { Context, env, logging } from 'near-sdk-as'
 import { Promise, ReturnedPromise, Vote, promises } from './model';
 
 /**

--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -13,7 +13,7 @@ import { Promise, ReturnedPromise, Vote, promises } from './model';
  * NOTE: This is a NOT a view method at the moment. Which means it costs money so shouldn't be executed too frequently.
  */
 export function getPromises(target: string): ReturnedPromise[] {
-  assert(Context.predecessor == Context.sender)
+  assertDirectCall()
 
   const result = new Array<ReturnedPromise>()
   const forMe = (target == 'me')
@@ -38,7 +38,7 @@ export function getPromises(target: string): ReturnedPromise[] {
 }
 
 export function vote(promiseId: i32, value: boolean): ReturnedPromise {
-  assert(Context.predecessor == Context.sender)
+  assertDirectCall()
   assert(promiseId >= 0 && promiseId < promises.length)
 
   logging.log('vote: sender = ' + Context.sender + ', promiseId = ' + promiseId.toString() + ', value = ' + value.toString() + ', total promises = ' + promises.length.toString())
@@ -95,7 +95,7 @@ export function vote(promiseId: i32, value: boolean): ReturnedPromise {
 }
 
 export function makePromise(what: string, viewers: string[] = [], voters: string[] = []): ReturnedPromise {
-  assert(Context.predecessor == Context.sender)
+  assertDirectCall()
 
   var promise = new Promise(what)
   for (let i = 0; i < viewers.length; ++i) {
@@ -124,8 +124,13 @@ export function makePromise(what: string, viewers: string[] = [], voters: string
 
 // debug only
 export function clearAll(): void {
-  assert(Context.predecessor == Context.sender)
+  assertDirectCall()
 
   while (promises.length !== 0)
     promises.pop();
+}
+
+function assertDirectCall(): void {
+  const message = "This method must be called directly.  No cross-contract calls allowed"
+  assert(Context.predecessor == Context.sender, message)
 }

--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -97,29 +97,10 @@ export function vote(promiseId: i32, value: boolean): ReturnedPromise {
 export function makePromise(what: string, viewers: string[] = [], voters: string[] = []): ReturnedPromise {
   assertDirectCall()
 
-  const promise = new Promise(what)
-  for (let i = 0; i < viewers.length; ++i) {
-    let viewer = viewers[i];
-    assert(env.isValidAccountID(viewer), "viewer account is invalid")
-
-    logging.log('adding viewer: ' + viewer)
-    promise.canView.add(viewer)
-  }
-
-  for (let i = 0; i < voters.length; ++i) {
-    let voter = voters[i];
-    assert(env.isValidAccountID(voter), "voter account is invalid")
-
-    logging.log('adding voter: ' + voter)
-    promise.canVote.add(voter)
-
-    // all voters are viewers too, otherwise how can they vote?
-    logging.log('adding voter to viewers: ' + voter)
-    promise.canView.add(voter)
-  }
+  const promise = new Promise(what, viewers, voters)
 
   promises.push(promise);
-  return new ReturnedPromise(promises.length - 1, promises[promises.length - 1])
+  return new ReturnedPromise(promises.length - 1, promise)
 }
 
 // debug only

--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -5,17 +5,17 @@
  *
  */
 
-import { Context, env, logging } from 'near-sdk-as'
-import { Promise, ReturnedPromise, Vote, promises } from './model';
+import { Context, logging } from 'near-sdk-as'
+import { Promise, Vote, promises } from './model';
 
 /**
  * Returns an array of last N promises.\
  * NOTE: This is a NOT a view method at the moment. Which means it costs money so shouldn't be executed too frequently.
  */
-export function getPromises(target: string): ReturnedPromise[] {
+export function getPromises(target: string): Promise[] {
   assertDirectCall()
 
-  const result = new Array<ReturnedPromise>()
+  const result = new Array<Promise>()
   const forMe = (target == 'me')
   // logging.log('getPromises: sender = ' + Context.sender + ', target = ' + target + ', forMe = ' + forMe.toString())
 
@@ -25,19 +25,19 @@ export function getPromises(target: string): ReturnedPromise[] {
     let promise = promises[i]
     if (forMe == true) {
       if (promise.who == Context.sender)
-        result.push(new ReturnedPromise(i, promise))
+        result.push(promise)
     } else {
       const isPublicNotMinePromise = promise.canView.size == 0 && promise.who != Context.sender
       const canViewPromise = (isPublicNotMinePromise ? true : promise.canView.has(Context.sender))
 
       if (canViewPromise)
-        result.push(new ReturnedPromise(i, promise))
+        result.push(promise)
     }
   }
   return result;
 }
 
-export function vote(promiseId: i32, value: boolean): ReturnedPromise {
+export function vote(promiseId: i32, value: boolean): Promise {
   assertDirectCall()
   assert(promiseId >= 0 && promiseId < promises.length)
 
@@ -91,16 +91,15 @@ export function vote(promiseId: i32, value: boolean): ReturnedPromise {
     + promise.vote_yes.toString() + "/" + promise.vote_no.toString())
 
   promises.replace(promiseId, promise);
-  return new ReturnedPromise(promiseId, promises[promiseId])
+  return promise
 }
 
-export function makePromise(what: string, viewers: string[] = [], voters: string[] = []): ReturnedPromise {
+export function makePromise(what: string, viewers: string[] = [], voters: string[] = []): Promise {
   assertDirectCall()
 
   const promise = new Promise(what, viewers, voters)
 
-  promises.push(promise);
-  return new ReturnedPromise(promises.length - 1, promise)
+  return promise
 }
 
 // debug only

--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -94,7 +94,7 @@ export function vote(promiseId: i32, value: boolean): ReturnedPromise {
   return new ReturnedPromise(promiseId, promises[promiseId])
 }
 
-export function makeExtendedPromise(what: string, viewers: string[], voters: string[]): ReturnedPromise {
+export function makePromise(what: string, viewers: string[] = [], voters: string[] = []): ReturnedPromise {
   assert(Context.predecessor == Context.sender)
 
   var promise = new Promise(what)
@@ -119,13 +119,6 @@ export function makeExtendedPromise(what: string, viewers: string[], voters: str
   }
 
   promises.push(promise);
-  return new ReturnedPromise(promises.length - 1, promises[promises.length - 1])
-}
-
-export function makePromise(what: string): ReturnedPromise {
-  assert(Context.predecessor == Context.sender)
-
-  promises.push(new Promise(what));
   return new ReturnedPromise(promises.length - 1, promises[promises.length - 1])
 }
 

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -10,18 +10,15 @@ export enum Vote {
  */
 @nearBindgen
 export class Promise {
-  who: string;
+  who: string = Context.sender;
   vote_yes: u64 = 0;
   vote_no: u64 = 0;
-  timestamp: u64 = 0;
+  timestamp: u64 = Context.blockTimestamp;
   votes: Map<string, Vote> = new Map<string, Vote>();
   canView: Set<string> = new Set<string>();
   canVote: Set<string> = new Set<string>();
 
-  constructor(public what: string) {
-    this.who = Context.sender;
-    this.timestamp = Context.blockTimestamp;
-  }
+  constructor(public what: string) { }
 }
 
 @nearBindgen

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -1,5 +1,6 @@
 import { Context, PersistentVector, logging, env } from "near-sdk-as";
 
+type PromiseId = i32;
 type AccountId = string;
 type VoteTally = u64;
 type Timestamp = u64;
@@ -14,6 +15,7 @@ export enum Vote {
  */
 @nearBindgen
 export class Promise {
+  id: PromiseId;
   who: AccountId = Context.sender;
   vote_yes: VoteTally = 0;
   vote_no: VoteTally = 0;
@@ -42,12 +44,9 @@ export class Promise {
       logging.log('adding voter to viewers: ' + voter)
       this.canView.add(voter)
     }
-  }
-}
 
-@nearBindgen
-export class ReturnedPromise {
-  constructor(public id: i32, public promise: Promise) {
+    this.id = promises.length
+    promises.push(this);
   }
 }
 

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -1,4 +1,4 @@
-import { Context, PersistentVector } from "near-sdk-as";
+import { Context, PersistentVector, logging, env } from "near-sdk-as";
 
 type AccountId = string;
 type VoteTally = u64;
@@ -22,7 +22,27 @@ export class Promise {
   canView: Set<AccountId> = new Set<AccountId>();
   canVote: Set<AccountId> = new Set<AccountId>();
 
-  constructor(public what: string) { }
+  constructor(public what: string, viewers: AccountId[], voters: AccountId[]) {
+    for (let i = 0; i < viewers.length; ++i) {
+      let viewer = viewers[i];
+      assert(env.isValidAccountID(viewer), `Viewer (${viewer}) account is invalid`)
+
+      logging.log('adding viewer: ' + viewer)
+      this.canView.add(viewer)
+    }
+
+    for (let i = 0; i < voters.length; ++i) {
+      let voter = voters[i];
+      assert(env.isValidAccountID(voter), `Voter (${voter}) account is invalid`)
+
+      logging.log('adding voter: ' + voter)
+      this.canVote.add(voter)
+
+      // all voters are viewers too, otherwise how can they vote?
+      logging.log('adding voter to viewers: ' + voter)
+      this.canView.add(voter)
+    }
+  }
 }
 
 @nearBindgen

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -1,5 +1,9 @@
 import { Context, PersistentVector } from "near-sdk-as";
 
+type AccountId = string;
+type VoteTally = u64;
+type Timestamp = u64;
+
 export enum Vote {
   No,
   Yes
@@ -10,13 +14,13 @@ export enum Vote {
  */
 @nearBindgen
 export class Promise {
-  who: string = Context.sender;
-  vote_yes: u64 = 0;
-  vote_no: u64 = 0;
-  timestamp: u64 = Context.blockTimestamp;
-  votes: Map<string, Vote> = new Map<string, Vote>();
-  canView: Set<string> = new Set<string>();
-  canVote: Set<string> = new Set<string>();
+  who: AccountId = Context.sender;
+  vote_yes: VoteTally = 0;
+  vote_no: VoteTally = 0;
+  timestamp: Timestamp = Context.blockTimestamp;
+  votes: Map<AccountId, Vote> = new Map<AccountId, Vote>();
+  canView: Set<AccountId> = new Set<AccountId>();
+  canVote: Set<AccountId> = new Set<AccountId>();
 
   constructor(public what: string) { }
 }

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -1,11 +1,11 @@
 import { Context, PersistentMap, PersistentVector } from "near-sdk-as";
 
 export enum Vote {
-    No,
-    Yes
+  No,
+  Yes
 }
 
-/** 
+/**
  * Exporting a new class Promise so it can be used outside of this file.
  */
 @nearBindgen
@@ -26,8 +26,8 @@ export class Promise {
 
 @nearBindgen
 export class ReturnedPromise {
-    constructor(public id: i32, public promise: Promise) {
-    }    
+  constructor(public id: i32, public promise: Promise) {
+  }
 }
 
 /**

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -1,4 +1,4 @@
-import { Context, PersistentMap, PersistentVector } from "near-sdk-as";
+import { Context, PersistentVector } from "near-sdk-as";
 
 export enum Vote {
   No,


### PR DESCRIPTION
changes are in the commit history.  

remaining notes are here: 

```
getPromises

- make sure to include error messages with assertions ("guard clause")
- no unbounded loops (index.ts:22)
- cleanup boolean logic (index.ts:26)
- encapsulate `canViewPromise` as a method on Promise class
- good code hygene (braces around if block)
- view vs call method design

vote

- encapsulate most of this logic in one or two methods on Promise class

? rename `who` to `author` or `originator` because it's the person who is making the promise

? remove ReturnedPromise class
  - replace with static `create()` method on Promise class
  - embed the PersistentVector id into the Promise class

---

refactor string concatenation in the generate function
refactor calls to Context.sender to save on gas

---

WILL NOT DO

? model: save on loading data by replacing Map and Set with PersistentMap, PersistentSet
```